### PR TITLE
Use the API domain in memcache keys

### DIFF
--- a/gfw/common.py
+++ b/gfw/common.py
@@ -17,6 +17,7 @@
 
 """This module supports common functions."""
 
+import copy
 import json
 import re
 import logging
@@ -104,9 +105,12 @@ class CORSRequestHandler(webapp2.RequestHandler):
             self.write_error(400, 'Unknown action %s' % action)
 
     def get_id(self, params):
-        whitespace = re.compile(r'\s+')
-        params = re.sub(whitespace, '', json.dumps(params, sort_keys=True))
-        return '/'.join([self.request.path.lower(), md5(params).hexdigest()])
+        normalized_params = copy.copy(params)
+        if 'bust' in normalized_params: normalized_params.pop('bust')
+        normalized_params = json.dumps(normalized_params, sort_keys=True)
+        normalized_params = re.sub(re.compile(r'\s+'), '', normalized_params)
+
+        return md5(self.request.host + self.request.path + normalized_params).hexdigest()
 
 #
 # SHARED CONSTANTS/TEMPLATES

--- a/gfw/pubsub/handlers.py
+++ b/gfw/pubsub/handlers.py
@@ -17,6 +17,7 @@
 
 """This module supports pubsub."""
 
+import copy
 import json
 import webapp2
 import monitor
@@ -111,9 +112,12 @@ class BaseApi(webapp2.RequestHandler):
             taskqueue.add(url='/log/error', params=error, queue_name="log")
 
     def _get_id(self, params):
-        whitespace = re.compile(r'\s+')
-        params = re.sub(whitespace, '', json.dumps(params, sort_keys=True))
-        return '/'.join([self.request.path.lower(), md5(params).hexdigest()])
+        normalized_params = copy.copy(params)
+        if 'bust' in normalized_params: normalized_params.pop('bust')
+        normalized_params = json.dumps(normalized_params, sort_keys=True)
+        normalized_params = re.sub(re.compile(r'\s+'), '', normalized_params)
+
+        return md5(self.request.host + self.request.path + normalized_params).hexdigest()
 
     def _get_params(self, body=False):
         if body and self.request.body:

--- a/gfw/stories.py
+++ b/gfw/stories.py
@@ -206,9 +206,12 @@ class BaseApi(webapp2.RequestHandler):
             taskqueue.add(url='/log/error', params=error, queue_name="log")
 
     def _get_id(self, params):
-        whitespace = re.compile(r'\s+')
-        params = re.sub(whitespace, '', json.dumps(params, sort_keys=True))
-        return '/'.join([self.request.path.lower(), hashlib.md5(params).hexdigest()])
+        normalized_params = copy.copy(params)
+        if 'bust' in normalized_params: normalized_params.pop('bust')
+        normalized_params = json.dumps(normalized_params, sort_keys=True)
+        normalized_params = re.sub(re.compile(r'\s+'), '', normalized_params)
+
+        return md5(self.request.host + self.request.path + normalized_params).hexdigest()
 
     def _get_params(self, body=False):
         if body:


### PR DESCRIPTION
Otherwise the cache will be shared across versions (production and staging). Also I changed it so that the `bust` param isn't included in the cache key, as that meant that adding `bust` didn't actually clear the cache :grinning: 