### PR TITLE
Function change

### DIFF
--- a/gfw/middlewares/cors.py
+++ b/gfw/middlewares/cors.py
@@ -101,8 +101,9 @@ class CORSRequestHandler(webapp2.RequestHandler):
 
         result = {}
         for key, val in raw.iteritems():
-            if only and key in only:
-                result[key] = val
+            if only:
+                if key in only:
+                    result[key] = val
             else:
                 result[key] = val
 


### PR DESCRIPTION
I think the function `args(self, only=[])` was always returning the full dictionary of keys/values. By nesting the if statements, there is a way that the key/value pair can end up not being entered into result dictionary if: 1) 'only' was supplied and 2) it's not specified there.